### PR TITLE
Improve CI to catch old Python versions issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,11 +11,13 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.8", "3.9", "3.11"]
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v5
         with:
-          fetch-depth: 0
+          python-version: ${{ matrix.python-version }}
       - name: Test
-        run: |
-          bash tests/run.sh
+        run: bash tests/run.sh

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,20 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "git grok: push local commits as individual PRs",
+      "detail": "Install git-grok first: https://github.com/dimikot/git-grok",
+      "type": "shell",
+      "command": "git grok",
+      "problemMatcher": [],
+      "hide": false
+    },
+    {
+      "label": "git rebase --interactive",
+      "detail": "Opens a UI for interactive rebase (install \"Git rebase shortcuts\" extension).",
+      "type": "shell",
+      "command": "GIT_EDITOR=\"code --wait\" git rebase -i",
+      "problemMatcher": []
+    }
+  ]
+}

--- a/git-grok
+++ b/git-grok
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 from __future__ import annotations
-
 import argparse
 import json
 import os

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
-cd $(dirname "${BASH_SOURCE[0]}")
+set -e -o pipefail
+cd "$(dirname "${BASH_SOURCE[0]}")"
 
-python3 -B -m unittest discover -s . -p '*_test.py' $@
+python3 -B -m unittest discover -s . -p '*_test.py' "$@"


### PR DESCRIPTION
## Summary

Some Python features, like ParamSpec, are available in newest versions only, so we can't use them considering git-grok is a zero-dependencies tool.

## How was this tested?

CI run.

## PRs in the Stack
- ➡ #15

(The stack is managed by [git-grok](https://github.com/dimikot/git-grok).)
