### PR TITLE
Partially switch to atomic multi-branch push

### DIFF
--- a/git-grok
+++ b/git-grok
@@ -7,6 +7,7 @@ import os
 import random
 import re
 import shlex
+import signal
 import subprocess
 import sys
 import traceback
@@ -84,6 +85,15 @@ class Pr:
     state: Literal["OPEN", "CLOSED", "MERGED"]
     auto_merge_status: Literal["ENABLED", "DISABLED"]
     labels: list[str]
+
+
+#
+# A pair of commit hash and branch name.
+#
+@dataclass
+class Branch:
+    hash: str
+    branch: str
 
 
 #
@@ -228,14 +238,14 @@ class Main:
                     commit_with_no_url = commit
                     break
                 else:
-                    # Push this branch and see whether GitHub says whether it
-                    # was up to date or not.
+                    # Push this branch and see whether GitHub says that it was
+                    # up to date or not.
                     commit_hashes_to_push_branch.append(commit.hash)
 
         # Some commits have no related PRs (no GitHub URLs in the message)?
         # Create missing PRs and amend their messages (via rebase interactive).
         if commit_with_no_url:
-            self.process_create_missing_prs(
+            self.process_create_missing_prs_in_rebase_interactive(
                 earliest_hash=commit_with_no_url.hash,
                 commits=commits,
             )
@@ -261,6 +271,11 @@ class Main:
     # Runs the sync for only the top commit. This is an internal command which
     # is used during interactive rebase.
     #
+    # This workflow runs only when the tool finds a commit that has no PR URL in
+    # its description yet. If all commits have existing PR URLs (including the
+    # case when they were reordered), the interactive rebase workflow is not
+    # run; instead, the branches are just pushed, and the PRs are updated.
+    #
     def run_in_rebase_interactive(self, *, data: InRebaseInteractiveData):
         remote_commit = self.git_get_commits(
             latest_ref=f"remotes/{self.remote}/{self.remote_base_branch}",
@@ -273,12 +288,20 @@ class Main:
 
         self.print_header(f"Processing commit: {self.clean_title(commit.title)}")
 
+        to_push: list[Branch] = []
         if prev_commit.hash != remote_commit.hash:
-            prev_commit, result = self.process_commit_push_branch(commit=prev_commit)
+            prev_commit.branch = self.process_commit_infer_branch(commit=prev_commit)
+            to_push.append(Branch(hash=prev_commit.hash, branch=prev_commit.branch))
+        commit.branch = self.process_commit_infer_branch(commit=commit)
+        to_push.append(Branch(hash=commit.hash, branch=commit.branch))
+
+        push_results = self.git_push_branches(branches=to_push)
+
+        if prev_commit.branch in push_results:
             self.print_branch_result(
                 type="base",
-                branch=str(prev_commit.branch),
-                result=result,
+                branch=prev_commit.branch,
+                result=push_results[prev_commit.branch],
             )
         else:
             self.print_branch_result(
@@ -286,10 +309,12 @@ class Main:
                 branch=self.remote_base_branch,
                 result="up-to-date",
             )
-            prev_commit.branch = None
 
-        commit, result = self.process_commit_push_branch(commit=commit)
-        self.print_branch_result(type="head", branch=str(commit.branch), result=result)
+        self.print_branch_result(
+            type="head",
+            branch=commit.branch,
+            result=push_results[commit.branch],
+        )
 
         new_pr_title = commit.title
         new_pr_body = None
@@ -356,7 +381,7 @@ class Main:
                 if not prev_pr or prev_pr.head_branch != pr.base_branch:
                     raise UserException(
                         f"PR {pr.url} is auto-mergeable.\n"
-                        + "I can't update it at GitHub without risking to auto-merge to an wrong branch.\n"
+                        + "I can't update it at GitHub without risking to auto-merge to a wrong branch.\n"
                         + "Please disable auto-merge for the PR and try again."
                     )
 
@@ -365,7 +390,7 @@ class Main:
     # description, creates the missing PRs and updates commits descriptions with
     # the returned URL.
     #
-    def process_create_missing_prs(
+    def process_create_missing_prs_in_rebase_interactive(
         self,
         *,
         earliest_hash: str,
@@ -430,18 +455,38 @@ class Main:
         # We must iterate from the oldest commit to the newest one, because
         # previous commit PR's branch becomes the next commit PR's base branch.
         commits_old_to_new = list(reversed(commits))
+
+        # Collect commits/branches that need to be pushed.
+        to_push: dict[str, Branch] = {}
+        for commit in commits_old_to_new:
+            if (
+                self.debug_force_push_branches
+                or commit.hash in commit_hashes_to_push_branch
+            ):
+                commit.branch = self.process_commit_infer_branch(commit=commit)
+                to_push[commit.branch] = Branch(hash=commit.hash, branch=commit.branch)
+
+        push_results: dict[str, BranchPushResult] = {}
+
         for i, commit in enumerate(commits_old_to_new):
             self.print_header(f"Updating PR: {self.clean_title(commit.title)}")
 
-            if commit.hash in commit_hashes_to_push_branch:
-                commit, result = self.process_commit_push_branch(commit=commit)
-                if result == "pushed":
-                    self.print_branch_result(
-                        type="head",
-                        branch=str(commit.branch),
-                        result=result,
-                    )
-                commits_old_to_new[i] = commit
+            # Push branches sequentially, one by one, not in bulk. This is
+            # because when bulk-pushing after local commits reordering, GitHub
+            # may mark some PRs as merged and close them (this behavior is
+            # covered with a unit test).
+            if commit.branch in to_push:
+                push_results.update(
+                    self.git_push_branches(branches=[to_push[commit.branch]])
+                )
+
+            result = push_results.get(str(commit.branch), None)
+            if result == "pushed":
+                self.print_branch_result(
+                    type="head",
+                    branch=str(commit.branch),
+                    result=result,
+                )
 
             pr, result = self.process_update_pr(
                 prev_commit=commits_old_to_new[i - 1] if i > 0 else None,
@@ -456,24 +501,23 @@ class Main:
             commits_old_to_new[i].branch = pr.head_branch
 
     #
-    # Pushes an existing branch (it we know this commit's PR URL by querying
-    # GitHub), or creates a new branch based on commit title and pushes it.
+    # For a commit, infers its corresponding remote branch name by either
+    # querying it from the PR (when commit.url is set), or by building it from
+    # the commit title and hash.
     #
-    def process_commit_push_branch(
+    def process_commit_infer_branch(
         self,
         *,
         commit: Commit,
-    ) -> tuple[Commit, BranchPushResult]:
+    ) -> str:
         if commit.url:
-            pr = self.gh_get_pr(url=commit.url)
-            commit.branch = pr.head_branch
+            pr = self.gh_get_pr(url=commit.url)  # likely a cache hit
+            return pr.head_branch
         else:
-            commit.branch = self.build_branch_name(
+            return self.build_branch_name(
                 title=commit.title,
                 commit_hash=commit.hash,
             )
-        pushed = self.git_push_branch(branch=commit.branch, hash=commit.hash)
-        return commit, pushed
 
     #
     # Updates PR fields:
@@ -796,6 +840,8 @@ class Main:
     # Returns parsed commits between two refs in reverse-chronological order
     # (newest commits first, oldest last, as they're shown in "git log").
     #
+    # The returned commits will have branch = None, since it's unknown yet.
+    #
     def git_get_commits(
         self,
         *,
@@ -814,7 +860,6 @@ class Main:
         commits: list[Commit] = []
         for commit in re.split(r"^(?=commit )", out, flags=re.M)[1:]:
             try:
-
                 if not (
                     m := re.match(
                         r"commit (\w+)[^\n]*\n(.*?)\n\n(.*)$", commit, flags=re.S
@@ -860,9 +905,16 @@ class Main:
         return commits
 
     #
-    # Pushes a branch to remote GitHub.
+    # Pushes multiple branches atomically to remote GitHub. Returns a dict
+    # mapping branch names to their push results.
     #
-    def git_push_branch(self, *, branch: str, hash: str) -> BranchPushResult:
+    def git_push_branches(
+        self,
+        *,
+        branches: list[Branch],
+    ) -> dict[str, BranchPushResult]:
+        if not branches:
+            return {}
         # Git push is a quick no-op on GitHub end if the branch isn't changed
         # (it prints "Everything up-to-date"), so we always push and then verify
         # the output for the status (instead of fetching from the remote and
@@ -873,15 +925,26 @@ class Main:
                 "push",
                 "-f",
                 self.remote,
-                f"{hash}:refs/heads/{branch}",
+                *[f"{branch.hash}:refs/heads/{branch.branch}" for branch in branches],
             ],
             stderr_to_stdout=True,
         )
-        return (
-            "up-to-date"
-            if re.match(r"^[^\n]+up-to-date", out, flags=re.S)
-            else "pushed"
-        )
+        # If the hash is NOT mentioned in the output, it's either a short
+        # "Everything up-to-date" message (which means that ALL branches are
+        # unchanged), or THIS particular branch is up-to-date. I.e. if a branch
+        # is changed, git always prints its hash in the output, on one of the
+        # following formats:
+        # 1. * [new branch] 10dc4f6 -> grok/...
+        # 2. + 10dc4f6...b28d03e 10dc4f6 -> grok/... (forced update)
+        results: dict[str, BranchPushResult] = {
+            branch.branch: "up-to-date" for branch in branches
+        }
+        for branch in branches:
+            for line in out.splitlines():
+                if branch.hash in line:
+                    results[branch.branch] = "pushed"
+                    break
+        return results
 
     #
     # Runs an interactive rebase with the provided shell command.
@@ -1434,6 +1497,9 @@ class UserException(Exception):
 if __name__ == "__main__":
     try:
         sys.exit(Main().run())
+    except KeyboardInterrupt:
+        signal.signal(signal.SIGINT, signal.SIG_DFL)
+        os.kill(os.getpid(), signal.SIGINT)
     except UserException as e:
         print(re.sub(r"^", "❌ ", str(e), flags=re.M))
         sys.exit(1)


### PR DESCRIPTION
## Summary

Adding an engine which is able to push multiple branches (commits) atomically. For now, it still does most of the pushes sequentially, but using the parallel engine (with commits list size 1).

The problem is that multi-branch push can only be used safely when no commits reordering happened in the stack (otherwise, GitHub may mark some of intermediate PRs as merged prematurely, and there is no way out of it). That's why in the current PR, we do not utilize it much yet. It will be treated in the next PRs.

## How was this tested?

CI.

## PRs in the Stack
- #31
- #30
- ➡ #29

(The stack is managed by [git-grok](https://github.com/dimikot/git-grok).)
