### PR TITLE
Push multiple branches in the stack atomically if no commits reordering happened

### DIFF
--- a/git-grok
+++ b/git-grok
@@ -382,6 +382,14 @@ class Main:
             )
             if result != "up-to-date":
                 self.print_commit_message_updated()
+                updated_commit = self.git_get_commits(
+                    latest_ref="HEAD",
+                    count_back_in_time=1,
+                )[0]
+                self.git_assign_branch_to_hash(
+                    branch=commit.branch,
+                    hash=updated_commit.hash,
+                )
 
     #
     # Checks that the tool can process this stack of commits at all.
@@ -488,27 +496,38 @@ class Main:
                 commit.branch = self.process_commit_infer_branch(commit=commit)
                 to_push[commit.branch] = Branch(hash=commit.hash, branch=commit.branch)
 
-        push_results: dict[str, BranchPushResult] = {}
+        push_results = {}
+        if to_push and self.git_commits_were_not_reordered(commits=commits):
+            self.print_header(
+                f"Pushing {len(to_push)} PR head{'s' if len(to_push) > 1 else ''} atomically:"
+            )
+            push_results = self.git_push_branches(branches=[*to_push.values()])
+            for branch, result in push_results.items():
+                self.print_branch_result(
+                    type="head",
+                    branch=branch,
+                    result=result,
+                )
 
         for i, commit in enumerate(commits_old_to_new):
             self.print_header(f"Updating PR: {self.clean_title(commit.title)}")
 
-            # Push branches sequentially, one by one, not in bulk. This is
-            # because when bulk-pushing after local commits reordering, GitHub
-            # may mark some PRs as merged and close them (this behavior is
-            # covered with a unit test).
-            if commit.branch in to_push:
+            # If we did not push this branch yet (e.g. because the commits were
+            # reordered), push the branches sequentially, interleaving the
+            # pushes with PR updates. This minimizes the chance that GitHub will
+            # close some of PRs or mark them as merged in case of commits
+            # reordering (but it still may happen rarely, just unlikely).
+            if commit.branch in to_push and commit.branch not in push_results:
                 push_results.update(
                     self.git_push_branches(branches=[to_push[commit.branch]])
                 )
-
-            result = push_results.get(str(commit.branch), None)
-            if result == "pushed":
-                self.print_branch_result(
-                    type="head",
-                    branch=str(commit.branch),
-                    result=result,
-                )
+                result = push_results[commit.branch]
+                if result == "pushed":
+                    self.print_branch_result(
+                        type="head",
+                        branch=str(commit.branch),
+                        result=result,
+                    )
 
             pr, result = self.process_update_pr(
                 prev_commit=commits_old_to_new[i - 1] if i > 0 else None,
@@ -1009,6 +1028,20 @@ class Main:
         return results
 
     #
+    # Assigns the provided commit hash to the remote branch without pushing it.
+    # This is useful after e.g. changing the commit message.
+    #
+    def git_assign_branch_to_hash(self, *, branch: str, hash: str):
+        self.shell(
+            [
+                "git",
+                "update-ref",
+                f"refs/remotes/{self.remote}/{branch}",
+                f"{hash}",
+            ],
+        )
+
+    #
     # Runs an interactive rebase with the provided shell command.
     #
     def git_rebase_interactive_exec(
@@ -1060,6 +1093,24 @@ class Main:
             return "updated"
         else:
             return "up-to-date"
+
+    #
+    # Checks whether the order of the commits on top of the upstream remained
+    # the same since the last run. If so, we are e.g. allowed to push multiple
+    # branches in bulk, atomically.
+    #
+    def git_commits_were_not_reordered(self, *, commits: list[Commit]) -> bool:
+        latest_commit_branch = self.process_commit_infer_branch(commit=commits[0])
+        remote_commits = self.git_get_commits(
+            latest_ref=f"remotes/{self.remote}/{latest_commit_branch}",
+        )
+        commit_urls = [c.url for c in commits]
+        remote_commit_urls = [c.url for c in remote_commits]
+        self.debug_log_text(
+            text=f"Local URLs:  {str(commit_urls)}\n"
+            + f"Remote URLs: {str(remote_commit_urls)}"
+        )
+        return commit_urls == remote_commit_urls
 
     #
     # Runs a shell command returning results.

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 import json
+from pathlib import Path
 import re
 import shlex
 import sys
@@ -9,7 +10,7 @@ from datetime import datetime, timedelta, timezone
 from importlib.machinery import SourceFileLoader
 from importlib.util import spec_from_loader, module_from_spec
 from itertools import groupby
-from os import chdir, getcwd, mkdir, environ
+from os import chdir, getcwd, makedirs, environ
 from os.path import basename, dirname, realpath
 from platform import python_version
 from shutil import rmtree
@@ -68,8 +69,12 @@ def git_init_and_cd_to_test_dir(
     initial_branch: str,
     method: Literal["push.default", "set-upstream"],
 ):
-    rmtree(dir, ignore_errors=True)
-    mkdir(dir)
+    for path in Path(dir).glob("*"):
+        if path.is_dir():
+            rmtree(path)
+        else:
+            path.unlink()
+    makedirs(dir, exist_ok=True)
     chdir(dir)
     check_output_x("git", "init", f"--initial-branch={initial_branch}")
     check_output_x("git", "config", "user.name", "tests")

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -4,7 +4,12 @@ cd "$(dirname "${BASH_SOURCE[0]}")"
 
 rm -f /tmp/git-grok.log
 
-if ! python3 -B -m unittest discover -v -k "${*:-*}"; then
+test_names=()
+for arg in "$@"; do
+  test_names+=("-k" "${arg%.py}")
+done
+
+if ! python3 -B -m unittest discover -v "${test_names[@]}"; then
   echo
   cat /tmp/git-grok.log
   exit 1

--- a/tests/test_push_atomic.py
+++ b/tests/test_push_atomic.py
@@ -1,0 +1,26 @@
+__import__("sys").dont_write_bytecode = True
+from helpers import (
+    TestCaseWithEmptyTestRepo,
+    git_add_commit,
+    git_touch,
+    run_git_grok,
+)
+from unittest import main
+
+
+class Test(TestCaseWithEmptyTestRepo):
+    def test_push_atomic(self):
+        self.git_init_and_cd_to_test_dir()
+
+        git_touch("file-01")
+        git_add_commit("file-01")
+        git_touch("file-02")
+        git_add_commit("file-02-and-01")
+        run_git_grok(skip_update_prs=True)
+
+        print("> Running git-grok again for an atomic push...")
+        run_git_grok()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Git supports "atomic push" of multiple branches. We now use it in git-grok:

It is faster than pushing one by one.
It is possible that it improves CODEOWNERS-based reviewers addition when a large stack is reordered or rebased.

## How was this tested?

CI (there was a test that covers the usecase with reordering).

## PRs in the Stack
- ➡ #31

(The stack is managed by [git-grok](https://github.com/dimikot/git-grok).)
