### PR TITLE
Fix e.g. "re.PatternError: bad escape \s at position" error

### DIFF
--- a/git-grok
+++ b/git-grok
@@ -2052,8 +2052,9 @@ def body_suffix_upsert(
         BODY_SUFFIX_TITLE + "\n" + "\n".join(items) + "\n\n" + BODY_SUFFIX_FOOTER + "\n"
     )
     if re.search(BODY_SUFFIX_RE, body, flags=re.M | re.I | re.X):
-        return re.sub(BODY_SUFFIX_RE, suffix, body, flags=re.M | re.I | re.X)
-    return body.rstrip() + "\n\n" + suffix
+        return re.sub(BODY_SUFFIX_RE, lambda _: suffix, body, flags=re.M | re.I | re.X)
+    else:
+        return body.rstrip() + "\n\n" + suffix
 
 
 #
@@ -2065,7 +2066,7 @@ def body_build_from_injected_text(
 ) -> str:
     return re.sub(
         r"\s*" + re.escape(AI_PLACEHOLDER) + r"\s*",
-        f"\n\n{injected_text.text}\n\n",
+        lambda _: f"\n\n{injected_text.text}\n\n",
         injected_text.template_with_placeholder,
     )
 
@@ -2095,7 +2096,7 @@ def body_convert_to_injected_text(
 # Returns an AI hash comment.
 #
 def ai_hash_build(hash: str) -> str:
-    return re.sub(r"(?=-->)", ":" + hash, AI_PLACEHOLDER)
+    return re.sub(r"(?=-->)", lambda _: f":{hash}", AI_PLACEHOLDER)
 
 
 #

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -197,8 +197,9 @@ def git_init_and_cd_to_test_dir(
     # branch has already been deleted by a parallel test run or so).
 
 
-def git_touch(file: str):
-    check_output_x("touch", file)
+def git_touch(file: str, content: str | None = None):
+    with open(file, "w") as f:
+        f.write(content or "")
 
 
 def git_add_commit(msg: str):

--- a/tests/test_ai.py
+++ b/tests/test_ai.py
@@ -11,7 +11,7 @@ from unittest import main
 class Test(TestCaseWithEmptyTestRepo):
     def test_ai(self):
         self.git_init_and_cd_to_test_dir(method="push.default")
-        git_touch("commit01")
+        git_touch("commit01", r"some \s text")
         git_add_commit("commit01")
         run_git_grok()
 


### PR DESCRIPTION
## Summary

<!--AI:61d54311-->
Fixing the regular expression pattern error in the Python script by adjusting the handling of escape sequences. This change resolves the issue where the script would throw a `re.PatternError` due to incorrect escape sequences like `\s` in regex patterns. The modification involves using a lambda function to ensure that the replacement string in `re.sub` calls is treated correctly, preventing the error from occurring.

### Essential Code Lines
```python
new_body = re.sub(BODY_SUFFIX_RE, lambda _: suffix, body, flags=re.M | re.I | re.X)
```

![CleanShot 2025-06-23 at 21 18 40@2x](https://github.com/user-attachments/assets/de52a321-89aa-46e9-9fad-f9755b11acbd)

## How was this tested?

```
python3 tests/test_ai.py
```

## PRs in the Stack
- ➡ #40

(The stack is managed by [git-grok](https://github.com/dimikot/git-grok).)
